### PR TITLE
Instructions for adding risc target

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 ## Building and flashing
 
-As the target is builtin to rust already, simply run 
+Add target to your toolchain
+```bash
+rustup target add riscv32imc-unknown-none-elf
+```
+
+As the target is ready, simply run
 ```bash
 cargo build --target riscv32imc-unknown-none-elf
 ```


### PR DESCRIPTION
@MabezDev Please review the following change.
I've added instruction how to add risc target. Without this command the build fails with:
```
error[E0463]: can't find crate for `core`
  |
  = note: the `riscv32imc-unknown-none-elf` target may not be installed
```