### PR TITLE
Make sure _sidata points to valid and correct address

### DIFF
--- a/riscv-link.x
+++ b/riscv-link.x
@@ -73,7 +73,6 @@ SECTIONS
   _rodata_size = _erodata - _srodata + 8;
   .data ORIGIN(DRAM) : AT(_text_size + _rodata_size)
   {
-    _sidata = LOADADDR(.data);
     _sdata = .;
     /* Must be called __global_pointer$ for linker relaxations to work. */
     PROVIDE(__global_pointer$ = . + 0x800);
@@ -120,6 +119,8 @@ SECTIONS
   .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
   .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
 }
+
+PROVIDE(_sidata = _erodata + 8);
 
 /* Do not exceed this mark in the error messages above                                    | */
 ASSERT(ORIGIN(REGION_TEXT) % 4 == 0, "

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,21 @@
 #![no_std]
 #![no_main]
-#![feature(asm)]
+#![feature(asm_const)]
 
 use embedded_hal::{digital::v2::OutputPin, prelude::_embedded_hal_timer_CountDown};
 use panic_halt as _;
 
-use core::fmt::Write;
+use core::{arch::asm, fmt::Write};
 use riscv_rt::entry;
 
 use esp32c3_lib::{disable_wdts, EtsTimer, GpioOutput, Uart};
 
+// make sure we have something in our rodata section
+#[used]
+static RODATA_SECTION_TEST: &'static str = "TEST DATA";
 // make sure we have something in our data section
 #[used]
-static DATA_SECTION_TEST: &'static str = "TEST DATA";
-// make sure we have something in our bss section
-#[used]
-static mut BSS_SECTION_TEST: [u8; 12] = [0xAA; 12];
+static mut DATA_SECTION_TEST: [u8; 12] = [0xAA; 12];
 
 #[entry]
 fn main() -> ! {
@@ -31,7 +31,10 @@ fn main() -> ! {
     let mut gpio = GpioOutput::new(9);
 
     writeln!(Uart, "Hello world!").unwrap();
-    writeln!(Uart, "{}", DATA_SECTION_TEST).unwrap();
+    writeln!(Uart, "{}", RODATA_SECTION_TEST).unwrap();
+    unsafe {
+        writeln!(Uart, "DATA_SECTION_TEST: {:x?}", DATA_SECTION_TEST).unwrap();
+    }
 
     let mut delay = EtsTimer::new(1_000_000);
 


### PR DESCRIPTION
I figured out that initialized mutable statics are not correctly initialized.
Reason for that is that _sidata points to a "weird" address. (i.e. to size of text plus size of rodata)

This should fix it. Besides the tiny change in the linker script there are some minor changes to adapt the current to work with a recent nightly compiler and printing the already present `static mut` to verify it's working

There seems to be a problem with _espflash_ so it still won't work but it works when flashed with probe-run 
